### PR TITLE
[Feat] 통계 API 기능 구현 및 Querydsl 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
@@ -46,4 +50,22 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// Querydsl
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }

--- a/src/main/java/com/wanted/preonboarding/config/QuerydslConfig.java
+++ b/src/main/java/com/wanted/preonboarding/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.wanted.preonboarding.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepository.java
+++ b/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepository.java
@@ -1,10 +1,9 @@
-package com.wanted.preonboarding.feed.repositroy;
+package com.wanted.preonboarding.feed.repository;
 
 import com.wanted.preonboarding.feed.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface FeedRepository extends JpaRepository<Feed, Long> {
-
+public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositoryCustom {
 }

--- a/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.wanted.preonboarding.feed.repository;
+
+import com.wanted.preonboarding.statistics.dto.FeedsCountByDateHourResponse;
+import com.wanted.preonboarding.statistics.dto.FeedsCountByDateResponse;
+import com.wanted.preonboarding.statistics.dto.StatisticsRequest;
+
+import java.util.List;
+
+public interface FeedRepositoryCustom {
+    List<FeedsCountByDateResponse> statisticFeedsCountContainHashtagByDate(StatisticsRequest request);
+    List<FeedsCountByDateHourResponse> statisticFeedsCountContainHashtagByHour(StatisticsRequest request);
+    Integer statisticFeedsSumBySortValue(StatisticsRequest request);
+}

--- a/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/wanted/preonboarding/feed/repository/FeedRepositoryCustomImpl.java
@@ -1,0 +1,89 @@
+package com.wanted.preonboarding.feed.repository;
+
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.preonboarding.feed.entity.QFeed;
+import com.wanted.preonboarding.hashtag.entity.QFeedHashTag;
+import com.wanted.preonboarding.hashtag.entity.QHashtag;
+import com.wanted.preonboarding.statistics.SortValue;
+import com.wanted.preonboarding.statistics.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    QFeed feed = QFeed.feed;
+    QHashtag hashTag = QHashtag.hashtag;
+    QFeedHashTag feedHashTag = QFeedHashTag.feedHashTag;
+
+    @Override
+    public List<FeedsCountByDateResponse> statisticFeedsCountContainHashtagByDate(StatisticsRequest request) {
+        StringTemplate formattedDate = Expressions.stringTemplate(
+                "DATE_FORMAT({0}, {1})",
+                feedHashTag.createdAt,
+                ConstantImpl.create("%Y-%m-%d"));
+
+        return queryFactory.select(new QFeedsCountByDateResponse(formattedDate, feedHashTag.count()))
+                .from(feedHashTag)
+                .where(hashTag.name.eq(request.getHashtag())
+                        .and(feedHashTag.createdAt
+                                .between(request.getStart(), request.getEnd().plusDays(1L))))
+                .join(hashTag).on(feedHashTag.hashtag.eq(hashTag))
+                .groupBy(formattedDate)
+                .orderBy(formattedDate.desc())
+                .fetch();
+    }
+
+    @Override
+    public List<FeedsCountByDateHourResponse> statisticFeedsCountContainHashtagByHour(StatisticsRequest request) {
+        StringTemplate formattedDateHour = Expressions.stringTemplate(
+                "DATE_FORMAT({0}, {1})",
+                feedHashTag.createdAt,
+                ConstantImpl.create("%Y-%m-%d %H:00"));
+
+        return queryFactory.select(new QFeedsCountByDateHourResponse(formattedDateHour, feedHashTag.count()))
+                .from(feedHashTag)
+                .where(hashTag.name.eq(request.getHashtag())
+                        .and(feedHashTag.createdAt
+                                .between(request.getStart(), request.getEnd().plusDays(1L))))
+                .join(hashTag).on(feedHashTag.hashtag.eq(hashTag))
+                .groupBy(formattedDateHour)
+                .orderBy(formattedDateHour.desc())
+                .fetch();
+    }
+
+    @Override
+    public Integer statisticFeedsSumBySortValue(StatisticsRequest request) {
+        NumberExpression<Integer> selectedField = getSelectedField(request.getSortValue(), feed);
+        return queryFactory.select(selectedField.sum())
+                .from(feed)
+                .join(feedHashTag).on(feedHashTag.feed.eq(feed))
+                .join(hashTag).on(feedHashTag.hashtag.eq(hashTag))
+                .where(hashTag.name.eq(request.getHashtag()))
+                .fetchFirst();
+    }
+
+    private NumberExpression<Integer> getSelectedField(SortValue sortValue, QFeed qFeed) {
+        switch (sortValue) {
+            case VIEW_COUNT -> {
+                return qFeed.viewCount;
+            }
+            case LIKE_COUNT -> {
+                return qFeed.likeCount;
+            }
+            case SHARE_COUNT -> {
+                return qFeed.shareCount;
+            }
+            default -> throw new IllegalArgumentException("invalid sort value");
+        }
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/feed/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/wanted/preonboarding/feed/service/impl/FeedServiceImpl.java
@@ -2,7 +2,7 @@ package com.wanted.preonboarding.feed.service.impl;
 
 import com.wanted.preonboarding.feed.dto.CreateFeedDto;
 import com.wanted.preonboarding.feed.entity.Feed;
-import com.wanted.preonboarding.feed.repositroy.FeedRepository;
+import com.wanted.preonboarding.feed.repository.FeedRepository;
 import com.wanted.preonboarding.feed.service.FeedService;
 import com.wanted.preonboarding.hashtag.entity.FeedHashTag;
 import com.wanted.preonboarding.hashtag.service.FeedHashTagService;

--- a/src/main/java/com/wanted/preonboarding/hashtag/entity/Hashtag.java
+++ b/src/main/java/com/wanted/preonboarding/hashtag/entity/Hashtag.java
@@ -10,17 +10,21 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name = "hashtag")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Table(name = "hashtag", indexes = {
+        @Index(name = "idx_name_idx", columnList = "name")})
 public class Hashtag {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hashtag_id")
     private Long hashTagId;
+
     private String name;
+
     @OneToMany(mappedBy = "hashtag")
     private Set<FeedHashTag> feedHashTag = new HashSet<>();
 

--- a/src/main/java/com/wanted/preonboarding/statistics/SortType.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/SortType.java
@@ -1,0 +1,13 @@
+package com.wanted.preonboarding.statistics;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortType {
+    DATE("date"),
+    HOUR("hour");
+
+    private final String value;
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/SortValue.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/SortValue.java
@@ -1,0 +1,15 @@
+package com.wanted.preonboarding.statistics;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SortValue {
+    COUNT("count"),
+    VIEW_COUNT("view_count"),
+    LIKE_COUNT("like_count"),
+    SHARE_COUNT("share_count");
+
+    private final String value;
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/controller/StatisticsController.java
@@ -1,0 +1,45 @@
+package com.wanted.preonboarding.statistics.controller;
+
+import com.wanted.preonboarding.security.user.UserPrincipal;
+import com.wanted.preonboarding.statistics.SortType;
+import com.wanted.preonboarding.statistics.SortValue;
+import com.wanted.preonboarding.statistics.dto.StatisticsRequest;
+import com.wanted.preonboarding.statistics.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feeds/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    public <T> ResponseEntity<List<T>> getStatistics(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                     @RequestParam(value = "hashtag", required = false) String hashtag,
+                                                     @RequestParam(value = "type") SortType type,
+                                                     @RequestParam(value = "value", required = false, defaultValue = "count") String value,
+                                                     @RequestParam(value = "start", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+                                                     @RequestParam(value = "end", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end) {
+
+        String account = userPrincipal.getUsername();
+        if(hashtag == null || hashtag.trim().isEmpty()) {
+            hashtag = account;
+        }
+        StatisticsRequest request = new StatisticsRequest(hashtag, type, SortValue.valueOf(value.toUpperCase()), start, end);
+        List<T> response = statisticsService.executeStatistics(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/dto/FeedsCountByDateHourResponse.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/dto/FeedsCountByDateHourResponse.java
@@ -1,0 +1,23 @@
+package com.wanted.preonboarding.statistics.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@ToString
+public class FeedsCountByDateHourResponse {
+
+    private final LocalDateTime datetime;
+    private final Long count;
+
+    @QueryProjection
+    public FeedsCountByDateHourResponse(String yyyyMMddHH, Long count) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:00");
+        this.datetime = LocalDateTime.parse(yyyyMMddHH, formatter);
+        this.count = count;
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/dto/FeedsCountByDateResponse.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/dto/FeedsCountByDateResponse.java
@@ -1,0 +1,22 @@
+package com.wanted.preonboarding.statistics.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@ToString
+public class FeedsCountByDateResponse {
+
+    private final LocalDate date;
+    private final Long count;
+
+    @QueryProjection
+    public FeedsCountByDateResponse(String yyyymmdd, Long count) {
+        this.date = LocalDate.parse(yyyymmdd, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        this.count = count;
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/dto/HashtagsCountResponse.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/dto/HashtagsCountResponse.java
@@ -1,0 +1,4 @@
+package com.wanted.preonboarding.statistics.dto;
+
+public record HashtagsCountResponse(String hashtag, Integer count) {
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/dto/StatisticsRequest.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/dto/StatisticsRequest.java
@@ -1,0 +1,65 @@
+package com.wanted.preonboarding.statistics.dto;
+
+import com.wanted.preonboarding.statistics.SortType;
+import com.wanted.preonboarding.statistics.SortValue;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.temporal.ChronoUnit;
+
+@Getter
+@ToString
+@Slf4j
+public class StatisticsRequest {
+
+    private final String hashtag;
+
+    private final SortType sortType;
+
+    private final SortValue sortValue;
+
+    private final LocalDateTime start;
+
+    private final LocalDateTime end;
+
+    public StatisticsRequest(String hashtag, SortType sortType, SortValue sortValue, LocalDate start, LocalDate end) {
+        this.hashtag = hashtag;
+        this.sortType = sortType;
+        this.sortValue = sortValue;
+        LocalDate now = LocalDate.now();
+        if (start == null) {
+            start = now.minusDays(7L);
+        }
+        if (end == null) {
+            end = now;
+        }
+        this.start = start.atStartOfDay();
+        this.end = end.atStartOfDay();
+        validateDate(now, start, end);
+    }
+    
+    private void validateDate(LocalDate now, LocalDate start, LocalDate end) {
+        LocalDate dayOfServiceStart = LocalDate.of(2020, Month.JANUARY, 2);
+        if(start.isBefore(dayOfServiceStart) || end.isBefore(dayOfServiceStart)) {
+            throw new IllegalArgumentException("non service day");
+        }
+        if(start.isAfter(now)) {
+            throw new IllegalArgumentException("start can't after now");
+        }
+        if(start.isAfter(end)) {
+            throw new IllegalArgumentException("start can't after end");
+        }
+        if(end.isAfter(now)){
+            throw new IllegalArgumentException("end can't after now");
+        }
+
+        long period = ChronoUnit.DAYS.between(start, end);
+        if(period >= 30) {
+            throw new IllegalArgumentException("period is up to 30 days");
+        }
+    }
+}

--- a/src/main/java/com/wanted/preonboarding/statistics/service/StatisticsService.java
+++ b/src/main/java/com/wanted/preonboarding/statistics/service/StatisticsService.java
@@ -1,0 +1,36 @@
+package com.wanted.preonboarding.statistics.service;
+
+import com.wanted.preonboarding.feed.repository.FeedRepository;
+import com.wanted.preonboarding.statistics.SortType;
+import com.wanted.preonboarding.statistics.SortValue;
+import com.wanted.preonboarding.statistics.dto.HashtagsCountResponse;
+import com.wanted.preonboarding.statistics.dto.StatisticsRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class StatisticsService {
+
+    private final FeedRepository feedRepository;
+
+    public <T> List<T> executeStatistics(StatisticsRequest request) {
+        SortValue sortValue = request.getSortValue();
+        if (sortValue == SortValue.LIKE_COUNT || sortValue == SortValue.SHARE_COUNT || sortValue == SortValue.VIEW_COUNT) {
+            Integer count = feedRepository.statisticFeedsSumBySortValue(request);
+            return (List<T>) List.of(new HashtagsCountResponse(request.getHashtag(), count));
+        }
+
+        if (request.getSortType() == SortType.DATE) {
+            return (List<T>) feedRepository.statisticFeedsCountContainHashtagByDate(request);
+        }
+        if (request.getSortType() == SortType.HOUR) {
+            return (List<T>) feedRepository.statisticFeedsCountContainHashtagByHour(request);
+        }
+        throw new RuntimeException("no case!");
+    }
+}

--- a/src/test/java/com/wanted/preonboarding/statistics/dto/StatisticsRequestTest.java
+++ b/src/test/java/com/wanted/preonboarding/statistics/dto/StatisticsRequestTest.java
@@ -1,0 +1,99 @@
+package com.wanted.preonboarding.statistics.dto;
+
+import com.wanted.preonboarding.statistics.SortType;
+import com.wanted.preonboarding.statistics.SortValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StatisticsRequestTest {
+
+    @Test
+    @DisplayName("생성자 테스트")
+    void constructor() {
+        LocalDate now = LocalDate.now();
+        StatisticsRequest request = new StatisticsRequest("danny", SortType.DATE, SortValue.COUNT, now, now);
+        assertThat(request).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Getter 테스트")
+    void getter() {
+        LocalDate start = LocalDate.now().minusDays(2L);
+        LocalDate end = LocalDate.now();
+        StatisticsRequest request = new StatisticsRequest("danny", SortType.DATE, SortValue.COUNT, start, end);
+
+        assertThat(request.getHashtag()).isEqualTo("danny");
+        assertThat(request.getSortType()).isSameAs(SortType.DATE);
+        assertThat(request.getSortValue()).isSameAs(SortValue.COUNT);
+        assertThat(request.getStart()).isEqualTo(start.atStartOfDay());
+        assertThat(request.getEnd()).isEqualTo(end.atStartOfDay());
+    }
+
+    @Test
+    @DisplayName("When Start Date: null -> 기본값 7일전 테스트")
+    void when_start_date_null() {
+        LocalDate now = LocalDate.now();
+        StatisticsRequest request = new StatisticsRequest("danny", SortType.DATE, SortValue.COUNT, null, now);
+
+        assertThat(request.getStart()).isEqualTo(now.minusDays(7L).atStartOfDay());
+    }
+
+    @Test
+    @DisplayName("When End Date: null -> 기본값 당일 테스트")
+    void when_end_date_null() {
+        LocalDate now = LocalDate.now();
+        StatisticsRequest request = new StatisticsRequest("danny", SortType.DATE, SortValue.COUNT, now, null);
+
+        assertThat(request.getStart()).isEqualTo(now.atStartOfDay());
+    }
+
+    @Test
+    @DisplayName("When Start Date: 서비스 제공 유효범위와 맞지않을때 예외처리")
+    void when_start_date_include_non_service_day_throw_exception() {
+        LocalDate now = LocalDate.of(1977, Month.APRIL, 17);
+        assertThatThrownBy(() -> new StatisticsRequest("apple2", SortType.DATE, SortValue.COUNT, now, now))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("When Start Date: 시작일이 오늘보다 이후일때 예외처리")
+    void when_start_date_is_after_today_throw_exception() {
+        LocalDate now = LocalDate.now();
+        LocalDate tomorrow = now.plusDays(1L);
+        assertThatThrownBy(() -> new StatisticsRequest("apple2", SortType.DATE, SortValue.COUNT, tomorrow, now))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("When Start Date: 시작일이 종료일보다 이후일때 예외처리")
+    void when_start_date_is_after_end_throw_exception() {
+        LocalDate now = LocalDate.now();
+        LocalDate yesterday = now.minusDays(1L);
+        assertThatThrownBy(() -> new StatisticsRequest("apple2", SortType.DATE, SortValue.COUNT, now, yesterday))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("When Start Date: 종료일이 오늘 이후일때 예외처리")
+    void when_end_date_is_after_today_throw_exception() {
+        LocalDate now = LocalDate.now();
+        LocalDate tomorrow = now.plusDays(1L);
+        assertThatThrownBy(() -> new StatisticsRequest("apple2", SortType.DATE, SortValue.COUNT, now, tomorrow))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("When Start & End Date: 시작일과 종료일 사이 기간이 30일이 초과할때 예외처리")
+    void when_start_date_between_end_date_up_to_30days_throw_exception() {
+        LocalDate start = LocalDate.of(2022, Month.JANUARY, 1);
+        LocalDate end = LocalDate.of(2022, Month.JANUARY, 31);
+        assertThatThrownBy(() -> new StatisticsRequest("apple2", SortType.DATE, SortValue.COUNT, start, end))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
# [Feat] 통계 API 기능 구현 및 Querydsl 설정

## 🔥 Issue Number
#4 

## 📄 Summary
- Querydsl: Gradle Clean & Build 하면 QClass파일이 생성됩니다.
- 주요 통계조회 기능
   - 해시태그가 포함된 게시글의 수 (날짜별, 시간별) 조회
   - 해시태그가 포함된 게시글들의 like_count, share_count, view_count의 총합 조회 (날짜별, 시간별 적용기능X)
   - 옵션: 시작일(기본값 7일전), 종료일(오늘)
- StatitsticRequest: 통계 요청 객체로 생성자에서 파라미터 기본값 설정과 파라미터의 검증 책임을 맡도록 함
   - Unit Test 작성 및  pass 확인 
- FeedRepositoryCustom 인터페이스를 FeedRepository가 상속받도록하여 FeedRepositoryImpl에서 구현한 통계쿼리를 FeedRepository에서 사용할 수 있도록 의존성 설정
- Dateformat (mysql) 함수 사용: "날짜패턴", "시간패턴"
- "2023-01-02" : 24 과 같은 형식으로 리턴해주기 위해서 QueryProjection을 사용한 DTO클래스 생성
   - 해당 DTO QClass가 생성되어 Querydsl의 Select절에서 사용이 가능하도록 구현
- 해시태그 컬럼 name 인덱싱 (where절에서 빈번하게 사용)
- DB Dummy Data로 API 결과 테스트 확인 완료

## 👨‍💻️ References

- [개인노션 통계API 구현과정 정리중] (https://www.notion.so/Feed-41849fe84fe945d9878dd85406d55eb5?pvs=4)

## 🙋‍ To reviewers
